### PR TITLE
Portability changes and makefile

### DIFF
--- a/Memes With Friends/Memes With Friends/.gitignore
+++ b/Memes With Friends/Memes With Friends/.gitignore
@@ -1,0 +1,4 @@
+*.d
+*.o
+MemesWithFriends
+*.zip

--- a/Memes With Friends/Memes With Friends/Card.cpp
+++ b/Memes With Friends/Memes With Friends/Card.cpp
@@ -37,7 +37,7 @@ Card::~Card()
 }
 
 /* Wrote this when I was tired to try to prevent issues where a bad image or non image gets put in the memes directory. Not sure if works but seems to so far. */
-const void Card::choose_meme(std::vector<const char *>& meme_list) {
+void Card::choose_meme(std::vector<const char *>& meme_list) {
 	fprintf(stdout, "Shuffling meme_list...\n");
 	std::random_shuffle(meme_list.begin(), meme_list.end());
 
@@ -84,7 +84,7 @@ std::vector<const char *> Card::list_memes(ALLEGRO_FS_ENTRY *dir)
 	return memes;
 }
 
-const void Card::draw()
+void Card::draw()
 {
 	if (!this->meme_image) return;
 
@@ -111,7 +111,7 @@ const void Card::draw()
 	al_draw_text(font, al_map_rgb(0, 0, 0), this->x1 + (this->CARD_W / 2) - (this->CARD_BORDER_WIDTH * 2), this->y1 + this->CARD_H - (this->CARD_BORDER_WIDTH * 2) - 10, ALLEGRO_ALIGN_LEFT, std::to_string(down).c_str());
 }
 
-const void Card::set_pos(int x1, int y1)
+void Card::set_pos(int x1, int y1)
 {
 	this->x1 = x1;
 	this->y1 = y1;
@@ -119,17 +119,17 @@ const void Card::set_pos(int x1, int y1)
 	this->y2 = y1 + Card::CARD_H;
 }
 
-const void Card::set_color(ALLEGRO_COLOR color)
+void Card::set_color(ALLEGRO_COLOR color)
 {
 	this->CARD_COLOR = color;
 }
 
-const void Card::set_font(ALLEGRO_FONT *font)
+void Card::set_font(ALLEGRO_FONT *font)
 {
 	this->font = font;
 }
 
-const void Card::set_gamedisplay(GameDisplay *gamedisplay)
+void Card::set_gamedisplay(GameDisplay *gamedisplay)
 {
 	this->gamedisplay = gamedisplay;
 }

--- a/Memes With Friends/Memes With Friends/Card.cpp
+++ b/Memes With Friends/Memes With Friends/Card.cpp
@@ -17,11 +17,11 @@ Card::Card()
 
 	fprintf(stdout, "Initializing new card...\n");
 	ALLEGRO_FS_ENTRY *dir = al_create_fs_entry("memes");
-	std::vector<const char *> meme_list = this->list_memes(dir);
+	std::vector<std::string> meme_list = this->list_memes(dir);
 
 	fprintf(stdout, "Listing meme list contents...\n");
-	for (std::vector<const char *>::const_iterator i = meme_list.begin(); i != meme_list.end(); ++i)
-		fprintf(stdout, "%s\n", *i);
+	for (std::vector<std::string>::const_iterator i = meme_list.begin(); i != meme_list.end(); ++i)
+		fprintf(stdout, "%s\n", i->c_str());
 
 	this->choose_meme(meme_list);
 
@@ -37,27 +37,27 @@ Card::~Card()
 }
 
 /* Wrote this when I was tired to try to prevent issues where a bad image or non image gets put in the memes directory. Not sure if works but seems to so far. */
-void Card::choose_meme(std::vector<const char *>& meme_list) {
+void Card::choose_meme(std::vector<std::string>& meme_list) {
 	fprintf(stdout, "Shuffling meme_list...\n");
 	std::random_shuffle(meme_list.begin(), meme_list.end());
 
-	fprintf(stdout, "Trying meme '%s'...\n", meme_list.front());
-	this->meme_image = al_load_bitmap(meme_list.front());
+	fprintf(stdout, "Trying meme '%s'...\n", meme_list.front().c_str());
+	this->meme_image = al_load_bitmap(meme_list.front().c_str());
 
 	if (!this->meme_image) {
-		fprintf(stdout, "Meme '%s' failed to load...\n", meme_list.front());
+		fprintf(stdout, "Meme '%s' failed to load...\n", meme_list.front().c_str());
 
 		this->choose_meme(meme_list);
 	}
 	else {
-		fprintf(stdout, "Chose meme '%s'...\n", meme_list.front());
+		fprintf(stdout, "Chose meme '%s'...\n", meme_list.front().c_str());
 		return;
 	}
 }
 
-std::vector<const char *> Card::list_memes(ALLEGRO_FS_ENTRY *dir)
+std::vector<std::string> Card::list_memes(ALLEGRO_FS_ENTRY *dir)
 {
-	std::vector<const char *> memes;
+	std::vector<std::string> memes;
 
 	ALLEGRO_FS_ENTRY *file;
 
@@ -75,8 +75,7 @@ std::vector<const char *> Card::list_memes(ALLEGRO_FS_ENTRY *dir)
 
 		fprintf(stdout, "Assigning '%s' to memes list\n", al_get_fs_entry_name(file));
 
-		char *filename = _strdup(al_get_fs_entry_name(file));
-		memes.push_back(filename);
+		memes.push_back(al_get_fs_entry_name(file));
 		al_destroy_fs_entry(file);
 	}
 	al_close_directory(dir);

--- a/Memes With Friends/Memes With Friends/Card.h
+++ b/Memes With Friends/Memes With Friends/Card.h
@@ -29,12 +29,12 @@ public:
 	const static int CARD_BORDER_WIDTH = 5;
 	Card();
 	~Card();
-	const void draw();
-	const void set_pos(int x1, int y1);
-	const void set_color(ALLEGRO_COLOR color);
-	const void set_font(ALLEGRO_FONT *font);
-	const void set_gamedisplay(GameDisplay *gamedisplay);
-	const void Card::choose_meme(std::vector<const char *>& meme_list);
+	void draw();
+	void set_pos(int x1, int y1);
+	void set_color(ALLEGRO_COLOR color);
+	void set_font(ALLEGRO_FONT *font);
+	void set_gamedisplay(GameDisplay *gamedisplay);
+	void choose_meme(std::vector<const char *>& meme_list);
 	std::vector<const char *> list_memes(ALLEGRO_FS_ENTRY *dir);
 	int get_up();
 	int get_down();

--- a/Memes With Friends/Memes With Friends/Card.h
+++ b/Memes With Friends/Memes With Friends/Card.h
@@ -34,8 +34,8 @@ public:
 	void set_color(ALLEGRO_COLOR color);
 	void set_font(ALLEGRO_FONT *font);
 	void set_gamedisplay(GameDisplay *gamedisplay);
-	void choose_meme(std::vector<const char *>& meme_list);
-	std::vector<const char *> list_memes(ALLEGRO_FS_ENTRY *dir);
+	void choose_meme(std::vector<std::string>& meme_list);
+	std::vector<std::string> list_memes(ALLEGRO_FS_ENTRY *dir);
 	int get_up();
 	int get_down();
 	int get_left();

--- a/Memes With Friends/Memes With Friends/Makefile
+++ b/Memes With Friends/Memes With Friends/Makefile
@@ -1,0 +1,29 @@
+PROG := MemesWithFriends
+
+PKG_CONFIG ?= pkg-config
+
+WARNINGS := -Wall -Wextra
+
+LIBS := allegro-5 allegro_font-5 allegro_image-5 allegro_physfs-5 \
+	allegro_primitives-5 allegro_ttf-5
+CXXFLAGS = -std=c++11 -O2 -flto $(WARNINGS) -MMD -MP \
+	   $(shell $(PKG_CONFIG) --cflags $(LIBS))
+LDFLAGS = -Wl,--as-needed -O2 -flto
+LDLIBS = $(shell $(PKG_CONFIG) --libs $(LIBS)) -lphysfs
+
+OBJ := main.o Card.o GameDisplay.o
+
+all: $(PROG)
+$(PROG): $(OBJ)
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) $(TARGET_ARCH) $^ $(LDLIBS) -o $@
+
+debug: all
+debug: CXXFLAGS += -ggdb -Og -Werror
+debug: LDFLAGS += -ggdb -Og
+
+clean:
+	$(RM) $(OBJ) $(OBJ:.o=.d) $(PROG) $(MANPAGE)
+
+-include $(OBJ:.o=.d)
+
+.PHONY: all debug clean

--- a/Memes With Friends/Memes With Friends/main.cpp
+++ b/Memes With Friends/Memes With Friends/main.cpp
@@ -12,7 +12,7 @@
 
 const float FPS = 60;
 
-int main(int argc, char **argv)
+int main(void)
 {
 	ALLEGRO_EVENT_QUEUE *event_queue = NULL;
 	ALLEGRO_TIMER *timer = NULL;


### PR DESCRIPTION
This pull request contains some portability fixes and the makefile.

One question remains - which version of the C++ standard should the project conform to?

Right now the Makefile is set to use C++14, but the project should compile under C++11.

Please do not merge until there's a decisive answer on this, I'll edit the makefile, rebase to squash and then force push the new patchset.

(Also, the makefile produces the file "MemesWithFriends" as "Memes With Friends" would screw with make.)

There are still some issues with the assets zip loading but I'll iron them out in a later patch.

This should tick some boxes on #12.

(Github shows the patches in the wrong order, seems to be a github bug.)